### PR TITLE
Workaround llvmlite being incompatible with current llvm - Bug #49

### DIFF
--- a/cpu.Dockerfile
+++ b/cpu.Dockerfile
@@ -3,6 +3,8 @@ FROM tensorflow/tensorflow:1.8.0-py3
 RUN mkdir /root/mimic2
 COPY . /root/mimic2
 WORKDIR /root/mimic2
-RUN pip install  --no-cache-dir -r requirements.txt
+RUN apt-get update -y && apt-get install -y llvm-8
+RUN ln -s /usr/bin/llvm-config-8 /usr/bin/llvm-config
+RUN pip install --no-cache-dir -r requirements.txt
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ tqdm==4.11.2
 seaborn
 flask_cors
 flask
+# Workaround llvmlite being incompatible with current llvm - Bug #49
+numba==0.45.1
+llvmlite==0.30.0


### PR DESCRIPTION
Docker installation is broken. This fixes it.
Fixes #49

My change to requirements.txt will also affect users who do not use docker. It might be better to make that change only for docker? Up to you to see.

Please modify my changes as you see fit.